### PR TITLE
Add depth frames to stereo module

### DIFF
--- a/launch/intel_d435i.launch
+++ b/launch/intel_d435i.launch
@@ -15,13 +15,22 @@
     </rosparam>
   </group>
 
+  <group ns="stereo/depth0/image" >
+    <rosparam param="disable_pub_plugins">
+      - "image_transport/compressed"
+      - "image_transport/compressedDepth"
+      - "image_transport/theora"
+    </rosparam>
+  </group>
+
   <group ns="stereo">
     <param name="global_time" type="bool" value="true" />
     <param name="sync_size" type="int" value="30" />
     <param name="enable_emitter" type="bool" value="false" />
 
     <param name="frame_rate" type="int" value="30" />
-    <param name="format" type="str" value="Y8" />
+    <param name="format_stereo" type="str" value="Y8" />
+    <param name="format_depth" type="str" value="Z16" />
     <param name="width" type="int" value="640" />
     <param name="height" type="int" value="480" />
     <param name="exposure" type="double" value="10000" />


### PR DESCRIPTION
Added support for depth frames in the stereo module. 

**Depth frames are aligned to the stereo camera 0 (default or left)**

* depth frames are published under the ros topic /stereo/depth
* format is CV_16UC1
* debug_imshow() works only for stereo images
* frame2cvmat() extended but backwards compatible
